### PR TITLE
Feature/add locking conductor

### DIFF
--- a/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
+++ b/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
@@ -5,11 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.1.1" />
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.3.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\AndcultureCode.CSharp.Core\src\AndcultureCode.CSharp.Core\AndcultureCode.CSharp.Core.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
+++ b/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.1.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\AndcultureCode.CSharp.Core\src\AndcultureCode.CSharp.Core\AndcultureCode.CSharp.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/AndcultureCode.CSharp.Conductors/Aspects/LockingConductor.cs
+++ b/src/AndcultureCode.CSharp.Conductors/Aspects/LockingConductor.cs
@@ -1,0 +1,240 @@
+using System;
+using AndcultureCode.CSharp.Core;
+using AndcultureCode.CSharp.Core.Extensions;
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Interfaces.Conductors;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using Microsoft.Extensions.Logging;
+
+namespace AndcultureCode.CSharp.Conductors.Aspects
+{
+    public class LockingConductor<T> : Conductor, ILockingConductor<T>
+        where T : class, ILockable, IEntity
+    {
+        #region Properties
+
+        private readonly ILogger<LockingConductor<T>> _logger;
+        private readonly IRepositoryReadConductor<T> _repositoryReadConductor;
+        private readonly IRepositoryUpdateConductor<T> _repositoryUpdateConductor;
+
+        #endregion Properties
+
+        #region Constants
+
+        public static readonly string ERROR_EXTEND_LOCK_LOCK_TIME_IN_PAST = $"{nameof(LockingConductor<T>)}.LockTimeInPast";
+        public static readonly string ERROR_EXTEND_LOCK_LOCKED_BY_DIFFERENT_USER = $"{nameof(LockingConductor<T>)}.ExtendLock.RecordLockedByDifferentUser";
+        public static readonly string ERROR_EXTEND_LOCK_RECORD_NOT_FOUND = $"{nameof(LockingConductor<T>)}.ExtendLock.ReadResultIsNull";
+        public static readonly string ERROR_EXTEND_LOCK_RECORD_NOT_LOCKED = $"{nameof(LockingConductor<T>)}.ExtendLock.RecordIsNotLocked";
+        public static readonly string ERROR_LOCK_RECORD_ALREADY_LOCKED = $"{nameof(LockingConductor<T>)}.{typeof(T).Name}.IsLocked";
+        public static readonly string ERROR_LOCK_RECORD_NOT_FOUND = $"{nameof(LockingConductor<T>)}.Lock.ReadResult.ResultObjectIsNull";
+        public static readonly string ERROR_LOCK_TIME_IN_PAST = $"{nameof(LockingConductor<T>)}.LockTimeInPast";
+        public static readonly string ERROR_UNLOCK_RECORD_NOT_FOUND = $"{nameof(LockingConductor<T>)}.Unlock.ReadResultIsNull";
+        public static readonly string ERROR_VALIDATE_LOCK_ITEM_IS_NULL = $"{nameof(LockingConductor<T>)}.ValidateLock.{typeof(T).Name}.IsNull";
+        public static readonly string ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED = $"{nameof(LockingConductor<T>)}.ValidateLock.{typeof(T).Name}.IsNotLocked";
+        public static readonly string ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER = $"{nameof(LockingConductor<T>)}.ValidateLock.{typeof(T).Name}.LockedByDifferentUser";
+
+        #endregion Constants
+
+        #region Constructor
+
+        public LockingConductor(
+            ILogger<LockingConductor<T>> logger,
+            IRepositoryReadConductor<T> repositoryReadConductor,
+            IRepositoryUpdateConductor<T> repositoryUpdateConductor
+        )
+        {
+            _logger = logger;
+            _repositoryReadConductor = repositoryReadConductor;
+            _repositoryUpdateConductor = repositoryUpdateConductor;
+        }
+
+        #endregion Constructor
+
+        #region ILockingConductor
+
+        public virtual IResult<T> Lock(long id, DateTimeOffset lockUntil, long? lockedById) => Do<T>.Try(r =>
+        {
+            var readResult = _repositoryReadConductor.FindById(id);
+
+            if (readResult.HasErrors)
+            {
+                r.AddErrors(readResult.Errors);
+                return null;
+            }
+
+            if (readResult.ResultObject == null)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_LOCK_RECORD_NOT_FOUND,
+                                 $"Read Result of {typeof(T).Name} id: {id} was null",
+                                 id);
+                return null;
+            }
+
+            var record = readResult.ResultObject;
+
+            if (record.IsLocked)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_LOCK_RECORD_ALREADY_LOCKED,
+                                 $"{typeof(T).Name} id: {id} is already locked",
+                                 id);
+                return null;
+            }
+
+            var now = DateTimeOffset.Now;
+
+            if (lockUntil < now)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_LOCK_TIME_IN_PAST,
+                                 $"LockedUntil time is in the past",
+                                 id);
+                return null;
+            }
+
+            record.LockedById = lockedById;
+            record.LockedOn = DateTimeOffset.Now;
+            record.LockedUntil = lockUntil;
+
+            var updateResult = _repositoryUpdateConductor.Update(record, lockedById);
+
+            if (updateResult.HasErrors)
+            {
+                r.AddErrors(updateResult.Errors);
+                return null;
+            }
+
+            return record;
+        }).Result;
+
+        public virtual IResult<T> Unlock(long id, long? unlockedById = null) => Do<T>.Try(r =>
+        {
+            var readResult = _repositoryReadConductor.FindById(id);
+
+            if (readResult.HasErrors)
+            {
+                r.AddErrors(readResult.Errors);
+                return null;
+            }
+
+            if (readResult.ResultObject == null)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_UNLOCK_RECORD_NOT_FOUND,
+                                 $"Read Result of {typeof(T).Name} id: {id} was null",
+                                 id);
+                return null;
+            }
+
+            var record = readResult.ResultObject;
+
+            record.LockedById = null;
+            record.LockedUntil = null;
+            record.LockedOn = null;
+
+            var updateResult = _repositoryUpdateConductor.Update(record, unlockedById);
+
+            if (updateResult.HasErrors)
+            {
+                r.AddErrors(updateResult.Errors);
+                return null;
+            }
+
+            return record;
+        }).Result;
+
+        public virtual IResult<T> ExtendLock(long id, DateTimeOffset lockUntil, long? updatedById) => Do<T>.Try(r =>
+        {
+            var readResult = _repositoryReadConductor.FindById(id);
+
+            if (readResult.HasErrors)
+            {
+                r.AddErrors(readResult.Errors);
+                return null;
+            }
+
+            if (readResult.ResultObject == null)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_EXTEND_LOCK_RECORD_NOT_FOUND,
+                                 $"Read Result of {typeof(T).Name} id: {id} was null",
+                                 id);
+                return null;
+            }
+
+            var record = readResult.ResultObject;
+
+            if (!record.IsLocked)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_EXTEND_LOCK_RECORD_NOT_LOCKED,
+                                 $"{typeof(T).Name} id: {id} is not currently locked",
+                                 id);
+                return null;
+            }
+
+            if (!updatedById.HasValue || record.LockedById != updatedById)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_EXTEND_LOCK_LOCKED_BY_DIFFERENT_USER,
+                                 $"{typeof(T).Name} id: {id} is locked by a different user",
+                                 id);
+                return null;
+            }
+
+            var now = DateTimeOffset.Now;
+
+            if (lockUntil < now)
+            {
+                r.AddErrorAndLog(_logger,
+                                 ERROR_EXTEND_LOCK_LOCK_TIME_IN_PAST,
+                                 "LockedUntil time is in the past",
+                                 id);
+                return null;
+            }
+
+            record.LockedUntil = lockUntil;
+
+            var updateResult = _repositoryUpdateConductor.Update(record, updatedById);
+
+            if (updateResult.HasErrors)
+            {
+                r.AddErrors(updateResult.Errors);
+                return null;
+            }
+
+            return record;
+        }).Result;
+
+        public virtual IResult<bool> ValidateLock(T item, long? currentUserId = null) => Do<bool>.Try(r =>
+        {
+            if (item == null)
+            {
+                r.AddErrorAndLog(_logger,
+                    ERROR_VALIDATE_LOCK_ITEM_IS_NULL,
+                    $"{typeof(T).Name} was null");
+                return false;
+            }
+
+            if (!item.IsLocked)
+            {
+                r.AddValidationError(ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED,
+                    $"{typeof(T).Name} no longer has a valid lock");
+                return false;
+            }
+
+            if (!currentUserId.HasValue || item.LockedById != currentUserId)
+            {
+                r.AddValidationError(ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER,
+                    $"{typeof(T).Name} is locked by another user");
+                return false;
+            }
+
+            return true;
+        }).Result;
+
+        #endregion ILockingConductor
+
+    }
+}

--- a/src/AndcultureCode.CSharp.Conductors/Aspects/LockingConductor.cs
+++ b/src/AndcultureCode.CSharp.Conductors/Aspects/LockingConductor.cs
@@ -64,10 +64,12 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
             if (readResult.ResultObject == null)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_LOCK_RECORD_NOT_FOUND,
-                                 $"Read Result of {typeof(T).Name} id: {id} was null",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_LOCK_RECORD_NOT_FOUND,
+                    $"Read Result of {typeof(T).Name} id: {id} was null",
+                    id
+                );
                 return null;
             }
 
@@ -75,10 +77,12 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
             if (record.IsLocked)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_LOCK_RECORD_ALREADY_LOCKED,
-                                 $"{typeof(T).Name} id: {id} is already locked",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_LOCK_RECORD_ALREADY_LOCKED,
+                    $"{typeof(T).Name} id: {id} is already locked",
+                    id
+                );
                 return null;
             }
 
@@ -86,10 +90,12 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
             if (lockUntil < now)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_LOCK_TIME_IN_PAST,
-                                 $"LockedUntil time is in the past",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_LOCK_TIME_IN_PAST,
+                    $"LockedUntil time is in the past",
+                    id
+                );
                 return null;
             }
 
@@ -120,10 +126,12 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
             if (readResult.ResultObject == null)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_UNLOCK_RECORD_NOT_FOUND,
-                                 $"Read Result of {typeof(T).Name} id: {id} was null",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_UNLOCK_RECORD_NOT_FOUND,
+                    $"Read Result of {typeof(T).Name} id: {id} was null",
+                    id
+                );
                 return null;
             }
 
@@ -156,10 +164,12 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
             if (readResult.ResultObject == null)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_EXTEND_LOCK_RECORD_NOT_FOUND,
-                                 $"Read Result of {typeof(T).Name} id: {id} was null",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_EXTEND_LOCK_RECORD_NOT_FOUND,
+                    $"Read Result of {typeof(T).Name} id: {id} was null",
+                    id
+                );
                 return null;
             }
 
@@ -167,19 +177,23 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
             if (!record.IsLocked)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_EXTEND_LOCK_RECORD_NOT_LOCKED,
-                                 $"{typeof(T).Name} id: {id} is not currently locked",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_EXTEND_LOCK_RECORD_NOT_LOCKED,
+                    $"{typeof(T).Name} id: {id} is not currently locked",
+                    id
+                );
                 return null;
             }
 
             if (!updatedById.HasValue || record.LockedById != updatedById)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_EXTEND_LOCK_LOCKED_BY_DIFFERENT_USER,
-                                 $"{typeof(T).Name} id: {id} is locked by a different user",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_EXTEND_LOCK_LOCKED_BY_DIFFERENT_USER,
+                    $"{typeof(T).Name} id: {id} is locked by a different user",
+                    id
+                );
                 return null;
             }
 
@@ -187,10 +201,12 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
             if (lockUntil < now)
             {
-                r.AddErrorAndLog(_logger,
-                                 ERROR_EXTEND_LOCK_LOCK_TIME_IN_PAST,
-                                 "LockedUntil time is in the past",
-                                 id);
+                r.AddErrorAndLog(
+                    _logger,
+                    ERROR_EXTEND_LOCK_LOCK_TIME_IN_PAST,
+                    "LockedUntil time is in the past",
+                    id
+                );
                 return null;
             }
 
@@ -211,23 +227,29 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
         {
             if (item == null)
             {
-                r.AddErrorAndLog(_logger,
+                r.AddErrorAndLog(
+                    _logger,
                     ERROR_VALIDATE_LOCK_ITEM_IS_NULL,
-                    $"{typeof(T).Name} was null");
+                    $"{typeof(T).Name} was null"
+                );
                 return false;
             }
 
             if (!item.IsLocked)
             {
-                r.AddValidationError(ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED,
-                    $"{typeof(T).Name} no longer has a valid lock");
+                r.AddValidationError(
+                    ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED,
+                    $"{typeof(T).Name} no longer has a valid lock"
+                );
                 return false;
             }
 
             if (!currentUserId.HasValue || item.LockedById != currentUserId)
             {
-                r.AddValidationError(ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER,
-                    $"{typeof(T).Name} is locked by another user");
+                r.AddValidationError(
+                    ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER,
+                    $"{typeof(T).Name} is locked by another user"
+                );
                 return false;
             }
 

--- a/test/AndcultureCode.CSharp.Conductors.Tests/AndcultureCode.CSharp.Conductors.Tests.csproj
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/AndcultureCode.CSharp.Conductors.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.1.1" />
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.3.0" />
     <PackageReference Include="AndcultureCode.CSharp.Testing" Version="0.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AndcultureCode.CSharp.Conductors\AndcultureCode.CSharp.Conductors.csproj" />
-    <ProjectReference Include="..\..\..\AndcultureCode.CSharp.Core\src\AndcultureCode.CSharp.Core\AndcultureCode.CSharp.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/AndcultureCode.CSharp.Conductors.Tests/AndcultureCode.CSharp.Conductors.Tests.csproj
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/AndcultureCode.CSharp.Conductors.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.1.1" />
-    <PackageReference Include="AndcultureCode.CSharp.Testing" Version="0.0.2" />
+    <PackageReference Include="AndcultureCode.CSharp.Testing" Version="0.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AndcultureCode.CSharp.Conductors\AndcultureCode.CSharp.Conductors.csproj" />
+    <ProjectReference Include="..\..\..\AndcultureCode.CSharp.Core\src\AndcultureCode.CSharp.Core\AndcultureCode.CSharp.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/AndcultureCode.CSharp.Conductors.Tests/Aspects/LockingConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/Aspects/LockingConductorTest.cs
@@ -1,0 +1,654 @@
+using System;
+using AndcultureCode.CSharp.Conductors.Aspects;
+using AndcultureCode.CSharp.Conductors.Tests.Stubs;
+using AndcultureCode.CSharp.Core.Interfaces.Conductors;
+using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Testing.Constants;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Testing.Extensions.Mocks;
+using AndcultureCode.CSharp.Testing.Extensions.Mocks.Conductors;
+using AndcultureCode.CSharp.Testing.Tests;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AndcultureCode.CSharp.Conductors.Tests.Aspects
+{
+    public class LockingConductorTest : BaseUnitTest
+    {
+        #region Setup
+        private static ILogger<LockingConductor<LockableEntity>> _logger => Mock.Of<ILogger<LockingConductor<LockableEntity>>>();
+
+        public LockingConductorTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        #endregion Setup
+
+        #region Lock
+
+        [Fact]
+        public void Lock_When_Record_Is_Successfully_Locked_Then_Returns_Updated_Result()
+        {
+            // Arrange
+            var repositoryUpdateConductorMock = new Mock<IRepositoryUpdateConductor<LockableEntity>>();
+            repositoryUpdateConductorMock
+                .Setup(m => m.Update(It.IsAny<LockableEntity>(), It.IsAny<long?>()))
+                .ReturnsGivenResult(true);
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, new LockableEntity()).Object;
+
+            var repositoryUpdateConductor = repositoryUpdateConductorMock.Object;
+
+            // Act
+            var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: repositoryUpdateConductor
+            );
+
+            var result = sut.Lock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                lockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldNotHaveErrors();
+            result.ResultObject.ShouldNotBeNull();
+            result.ResultObject.LockedById.ShouldBe(1);
+            result.ResultObject.LockedUntil.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Lock_When_FindById_Returns_Errors_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsBasicErrorResult(1).Object;
+
+            var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.Lock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                lockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);
+        }
+
+        [Fact]
+        public void Lock_When_FindById_Returns_Null_ResultObject_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, null).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.Lock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                lockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_LOCK_RECORD_NOT_FOUND);
+        }
+
+        [Fact]
+        public void Lock_When_Record_Is_Already_Locked_Then_Returns_Errors()
+        {
+            // Arrange
+            var record = new LockableEntity() { LockedUntil = GetFifteenMinutesInTheFuture() };
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, record).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.Lock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                lockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_LOCK_RECORD_ALREADY_LOCKED);
+        }
+
+        [Fact]
+        public void Lock_When_LockUntil_Is_In_The_Past_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, new LockableEntity()).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.Lock(
+                id: 1,
+                lockUntil: DateTimeOffset.Now.AddMinutes(-15),
+                lockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_LOCK_TIME_IN_PAST);
+        }
+
+        [Fact]
+        public void Lock_When_Update_Returns_Errors_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryUpdateConductorMock = new Mock<IRepositoryUpdateConductor<LockableEntity>>();
+            repositoryUpdateConductorMock
+                .Setup(m => m.Update(It.IsAny<LockableEntity>(), It.IsAny<long?>()))
+                .ReturnsBasicErrorResult();
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, new LockableEntity()).Object;
+            var repositoryUpdateConductor = repositoryUpdateConductorMock.Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: repositoryUpdateConductor
+            );
+
+            // Act
+            var result = sut.Lock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                lockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);;
+        }
+
+        #endregion Lock
+
+        #region Unlock
+
+        [Fact]
+        public void Unlock_When_Record_Is_Unlocked_Then_Returns_Updated_Record()
+        {
+            // Arrange
+            var repositoryUpdateConductorMock = new Mock<IRepositoryUpdateConductor<LockableEntity>>();
+            repositoryUpdateConductorMock
+                .Setup(m => m.Update(It.IsAny<LockableEntity>(), It.IsAny<long?>()))
+                .ReturnsGivenResult(true);
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, new LockableEntity()).Object;
+            var repositoryUpdateConductor = repositoryUpdateConductorMock.Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: repositoryUpdateConductor
+            );
+
+            // Act
+            var result = sut.Unlock(
+                id: 1,
+                unlockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldNotHaveErrors();
+            result.ResultObject.ShouldNotBeNull();
+            result.ResultObject.IsLocked.ShouldBeFalse();
+            result.ResultObject.LockedOn.ShouldBeNull();
+            result.ResultObject.LockedUntil.ShouldBeNull();
+            result.ResultObject.LockedById.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Unlock_When_FindById_Returns_Errors_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsBasicErrorResult(1).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.Unlock(
+                id: 1,
+                unlockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);;
+        }
+
+        [Fact]
+        public void Unlock_When_FindById_Returns_Null_ResultObject_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, null).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.Unlock(
+                id: 1,
+                unlockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_UNLOCK_RECORD_NOT_FOUND);
+        }
+
+        [Fact]
+        public void Unlock_When_Update_Returns_Errors_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryUpdateConductorMock = new Mock<IRepositoryUpdateConductor<LockableEntity>>();
+            repositoryUpdateConductorMock
+                .Setup(m => m.Update(It.IsAny<LockableEntity>(), It.IsAny<long?>()))
+                .ReturnsBasicErrorResult();
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, new LockableEntity()).Object;
+            var repositoryUpdateConductor = repositoryUpdateConductorMock.Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: repositoryUpdateConductor
+            );
+
+            // Act
+            var result = sut.Unlock(
+                id: 1,
+                unlockedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);;
+        }
+
+        #endregion Unlock
+
+        #region ExtendLock
+
+        [Fact]
+        public void ExtendLock_When_Lock_Time_Is_Extended_Then_Returns_Updated_Record()
+        {
+            // Arrange
+            var lockedUntil = DateTimeOffset.Now.AddMinutes(5);
+            var record = new LockableEntity()
+            {
+                LockedById = 1,
+                LockedOn = DateTimeOffset.Now,
+                LockedUntil = lockedUntil
+            };
+
+            var repositoryUpdateConductorMock = new Mock<IRepositoryUpdateConductor<LockableEntity>>();
+            repositoryUpdateConductorMock
+                .Setup(m => m.Update(It.IsAny<LockableEntity>(), It.IsAny<long?>()))
+                .ReturnsGivenResult(true);
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, record).Object;
+            var repositoryUpdateConductor = repositoryUpdateConductorMock.Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: repositoryUpdateConductor
+            );
+
+            // Act
+            var result = sut.ExtendLock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                updatedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldNotHaveErrors();
+            result.ResultObject.ShouldNotBeNull();
+            result.ResultObject.LockedUntil.ShouldNotBeNull();
+            result.ResultObject.LockedUntil.Value.ShouldBeGreaterThan(lockedUntil);
+        }
+
+        [Fact]
+        public void ExtendLock_When_FindById_Returns_Errors_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsBasicErrorResult(1).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ExtendLock(1, GetFifteenMinutesInTheFuture(), 1);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);;
+        }
+
+        [Fact]
+        public void ExtendLock_When_FindById_Returns_Null_ResultObject_Then_Returns_Errors()
+        {
+            // Arrange
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, null).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ExtendLock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                updatedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_EXTEND_LOCK_RECORD_NOT_FOUND);
+        }
+
+        [Fact]
+        public void ExtendLock_When_Record_Is_Not_Locked_Then_Returns_Errors()
+        {
+            // Arrange
+            var record = new LockableEntity() { LockedUntil = null };
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<Lockable>>()
+                .SetupFindByIdReturnsGivenResult(1, record).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: null,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ExtendLock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                updatedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_EXTEND_LOCK_RECORD_NOT_LOCKED);
+        }
+
+        [Fact]
+        public void ExtendLock_When_Record_Is_Locked_By_Another_User_Then_Returns_Errors()
+        {
+            // Arrange
+            var record = new LockableEntity()
+            {
+                LockedById = 2,
+                LockedUntil = DateTimeOffset.Now.AddMinutes(15)
+            };
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, record).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ExtendLock(
+                id: 1,
+                lockUntil: GetFifteenMinutesInTheFuture(),
+                updatedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_EXTEND_LOCK_LOCKED_BY_DIFFERENT_USER);
+        }
+
+        [Fact]
+        public void ExtendLock_When_Lock_Time_Is_In_Past_Then_Returns_Errors()
+        {
+            // Arrange
+            var record = new LockableEntity()
+            {
+                LockedById = 1,
+                LockedUntil = DateTimeOffset.Now.AddMinutes(10)
+            };
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, record).Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ExtendLock(
+                id: 1,
+                lockUntil: DateTimeOffset.Now.AddMinutes(-15),
+                updatedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_EXTEND_LOCK_LOCK_TIME_IN_PAST);
+        }
+
+        [Fact]
+        public void ExtendLock_When_Update_Returns_Errors_Then_Returns_Errors()
+        {
+            var record = new LockableEntity()
+            {
+                LockedById = 1,
+                LockedOn = DateTimeOffset.Now,
+                LockedUntil = DateTimeOffset.Now.AddMinutes(5)
+            };
+
+            var repositoryUpdateConductorMock = new Mock<IRepositoryUpdateConductor<LockableEntity>>();
+            repositoryUpdateConductorMock
+                .Setup(m => m.Update(It.IsAny<LockableEntity>(), It.IsAny<long?>()))
+                .ReturnsBasicErrorResult();
+
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
+                .SetupFindByIdReturnsGivenResult(1, record).Object;
+            var repositoryUpdateConductor = repositoryUpdateConductorMock.Object;
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: repositoryReadConductor,
+                repositoryUpdateConductor: repositoryUpdateConductor
+            );
+
+            // Act
+            var result = sut.ExtendLock(
+                id: 1,
+                lockUntil: DateTimeOffset.Now.AddMinutes(15),
+                updatedById: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);;
+        }
+
+        #endregion ExtendLock
+
+        #region ValidateLock
+
+        [Fact]
+        public void ValidateLock_When_Lock_Is_Valid_Then_Returns_True()
+        {
+            // Arrange
+            var record = new LockableEntity()
+            {
+                LockedById = 1,
+                LockedUntil = DateTimeOffset.Now.AddMinutes(15)
+            };
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: null,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ValidateLock(
+                item: record,
+                currentUserId: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldNotHaveErrors();
+            result.ResultObject.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ValidateLock_When_Record_Is_Null_Then_Returns_False()
+        {
+            // Arrange & Act
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: null,
+                repositoryUpdateConductor: null
+            );
+
+            var result = sut.ValidateLock(null);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_VALIDATE_LOCK_ITEM_IS_NULL);
+            result.ResultObject.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ValidateLock_When_Record_Lock_Is_Expired_Then_Returns_False()
+        {
+            // Arrange
+            var record = new LockableEntity()
+            {
+                LockedById = 1,
+                LockedUntil = DateTimeOffset.Now.AddMinutes(-15)
+            };
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: null,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ValidateLock(
+                item: record,
+                currentUserId: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED);
+        }
+
+        [Fact]
+        public void ValidateLock_When_Record_Is_Locked_By_A_Different_User_Then_Returns_False()
+        {
+            // Arrange
+            var record = new LockableEntity()
+            {
+                LockedById = 2,
+                LockedUntil = DateTimeOffset.Now.AddMinutes(15)
+            };
+
+             var sut = new LockingConductor<LockableEntity>(
+                logger: _logger,
+                repositoryReadConductor: null,
+                repositoryUpdateConductor: null
+            );
+
+            // Act
+            var result = sut.ValidateLock(
+                item: record,
+                currentUserId: 1
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER);
+        }
+
+        #endregion ValidateLock
+
+        #region Private Methods
+
+        private DateTimeOffset GetFifteenMinutesInTheFuture()
+        {
+            DateTimeOffset now = DateTimeOffset.Now;
+
+            return now.AddMinutes(15);
+        }
+
+        #endregion Helper Methods
+
+    }
+}

--- a/test/AndcultureCode.CSharp.Conductors.Tests/Aspects/LockingConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/Aspects/LockingConductorTest.cs
@@ -413,12 +413,12 @@ namespace AndcultureCode.CSharp.Conductors.Tests.Aspects
             // Arrange
             var record = new LockableEntity() { LockedUntil = null };
 
-            var repositoryReadConductor = new Mock<IRepositoryReadConductor<Lockable>>()
+            var repositoryReadConductor = new Mock<IRepositoryReadConductor<LockableEntity>>()
                 .SetupFindByIdReturnsGivenResult(1, record).Object;
 
              var sut = new LockingConductor<LockableEntity>(
                 logger: _logger,
-                repositoryReadConductor: null,
+                repositoryReadConductor: repositoryReadConductor,
                 repositoryUpdateConductor: null
             );
 
@@ -579,7 +579,7 @@ namespace AndcultureCode.CSharp.Conductors.Tests.Aspects
 
             // Assert
             result.ShouldNotBeNull();
-            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_VALIDATE_LOCK_ITEM_IS_NULL);
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_VALIDATE_LOCK_ITEM_IS_NULL);
             result.ResultObject.ShouldBeFalse();
         }
 
@@ -607,7 +607,7 @@ namespace AndcultureCode.CSharp.Conductors.Tests.Aspects
 
             // Assert
             result.ShouldNotBeNull();
-            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED);
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED);
         }
 
         [Fact]
@@ -634,7 +634,7 @@ namespace AndcultureCode.CSharp.Conductors.Tests.Aspects
 
             // Assert
             result.ShouldNotBeNull();
-            result.ShouldHaveErrorsFor(LockingConductor<Lockable>.ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER);
+            result.ShouldHaveErrorsFor(LockingConductor<LockableEntity>.ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER);
         }
 
         #endregion ValidateLock

--- a/test/AndcultureCode.CSharp.Conductors.Tests/Aspects/LockingConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/Aspects/LockingConductorTest.cs
@@ -25,7 +25,6 @@ namespace AndcultureCode.CSharp.Conductors.Tests.Aspects
         {
         }
 
-
         #endregion Setup
 
         #region Lock

--- a/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
 using System.Linq;
+using AndcultureCode.CSharp.Conductors.Tests.Stubs;
 using AndcultureCode.CSharp.Core.Interfaces;
 using AndcultureCode.CSharp.Core.Interfaces.Conductors;
 using AndcultureCode.CSharp.Core.Models;
 using AndcultureCode.CSharp.Core.Models.Entities;
-using AndcultureCode.CSharp.Testing;
 using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Testing.Tests;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -13,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace AndcultureCode.CSharp.Conductors.Tests
 {
-    public class RepositoryConductorTest : UnitTestBase
+    public class RepositoryConductorTest : BaseUnitTest
     {
         #region Setup
         public RepositoryConductorTest(ITestOutputHelper output) : base(output)
@@ -379,19 +380,19 @@ namespace AndcultureCode.CSharp.Conductors.Tests
             )).Returns(new Result<List<Entity>> {
                 ResultObject = null
             });
-            
+
             var sut = SetupSut(
                 createConductor: mockCreateConductor,
                 updateConductor: mockUpdateConductor);
 
             // Act
             var result = sut.CreateOrUpdate(entities, currentUserId);
-            
+
             // Assert
             result.ShouldHaveErrors();
             result.ResultObject.ShouldBeEmpty<Entity>();
         }
-        
+
         [Fact]
         public void CreateOrUpdate_When_Items_To_Update_And_No_Items_To_Create_And_Update_Is_Successful_Then_Returns_Null()
         {
@@ -415,14 +416,14 @@ namespace AndcultureCode.CSharp.Conductors.Tests
             )).Returns(new Result<List<Entity>> {
                 ResultObject = null
             });
-            
+
             var sut = SetupSut(
                 createConductor: mockCreateConductor,
                 updateConductor: mockUpdateConductor);
 
             // Act
             var result = sut.CreateOrUpdate(entities, currentUserId);
-            
+
             // Assert
             result.ShouldNotHaveErrors();
             result.ResultObject.ShouldBeEmpty();
@@ -456,20 +457,20 @@ namespace AndcultureCode.CSharp.Conductors.Tests
                 }},
                 ResultObject = null
             });
-            
+
             var sut = SetupSut(
                 createConductor: mockCreateConductor,
                 updateConductor: mockUpdateConductor);
 
             // Act
             var result = sut.CreateOrUpdate(entities, currentUserId);
-            
+
             // Assert
-            
+
             result.ShouldHaveErrorsFor(BASIC_ERROR_KEY);
             result.ResultObject.ShouldBeEmpty();
         }
-        
+
         [Fact]
         public void CreateOrUpdate_When_Items_To_Update_Do_Not_Exist_And_Items_To_Create_Exist_And_Create_is_Successful_Then_Returns_Created_Entities()
         {
@@ -497,14 +498,14 @@ namespace AndcultureCode.CSharp.Conductors.Tests
             )).Returns(new Result<List<Entity>> {
                 ResultObject = createdEntities
             });
-            
+
             var sut = SetupSut(
                 createConductor: mockCreateConductor,
                 updateConductor: mockUpdateConductor);
 
             // Act
             var result = sut.CreateOrUpdate(entities, currentUserId);
-        
+
             // Assert
             result.ShouldNotHaveErrors();
             result.ResultObject.ShouldBe(createdEntities);

--- a/test/AndcultureCode.CSharp.Conductors.Tests/stubs/LockableEntity.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/stubs/LockableEntity.cs
@@ -1,0 +1,9 @@
+using AndcultureCode.CSharp.Core.Models;
+
+namespace AndcultureCode.CSharp.Conductors.Tests.Stubs
+{
+    public class LockableEntity: Lockable
+    {
+        public string Name;
+    }
+}

--- a/test/AndcultureCode.CSharp.Conductors.Tests/stubs/TestEntity.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/stubs/TestEntity.cs
@@ -1,7 +1,6 @@
-using System;
 using AndcultureCode.CSharp.Core.Models.Entities;
 
-namespace AndcultureCode.CSharp.Conductors.Tests
+namespace AndcultureCode.CSharp.Conductors.Tests.Stubs
 {
     public class TestEntity : Entity
     {


### PR DESCRIPTION
Add default implementation for ILockingConductor interface

There is a need across projects to be able to "lock" resources on the server side to prevent users from modifying the same resource simultaneously. This provides a default implementation for the `ILockingConductor` interface.
Updates AndcultureCode.CSharp.Core to version 0.3.0
Updates AndcultureCode.CSharp.Testing to version 0.2.1