### PR TITLE
Add doc comments to Locking conductor and rev version of Core dependency

### DIFF
--- a/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
+++ b/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.3.0" />
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.5.15" />
   </ItemGroup>
 </Project>

--- a/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
+++ b/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
@@ -1,20 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Authors>andculture</Authors>
-    <Company>andculture</Company>
-    <Description>Commonly used interfaces, patterns and utilities by andculture engineering</Description>
-    <DocumentationFile>$(MSBuildProjectDirectory)/AndcultureCode.CSharp.Core.xml</DocumentationFile>
-    <DocumentationMarkdown>$(MSBuildProjectDirectory)/AndcultureCode.CSharp.Core.md</DocumentationMarkdown>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageIconUrl>https://avatars3.githubusercontent.com/u/32297579?s=460&amp;v=4</PackageIconUrl>
-    <PackageId>AndcultureCode.CSharp.Core</PackageId>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/AndcultureCode/AndcultureCode.CSharp.Core</PackageProjectUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.2</Version>
-    <VsxmdAutoDeleteXml>true</VsxmdAutoDeleteXml>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
+++ b/src/AndcultureCode.CSharp.Conductors/AndcultureCode.CSharp.Conductors.csproj
@@ -1,7 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Authors>andculture</Authors>
+    <Company>andculture</Company>
+    <Description>Commonly used interfaces, patterns and utilities by andculture engineering</Description>
+    <DocumentationFile>$(MSBuildProjectDirectory)/AndcultureCode.CSharp.Core.xml</DocumentationFile>
+    <DocumentationMarkdown>$(MSBuildProjectDirectory)/AndcultureCode.CSharp.Core.md</DocumentationMarkdown>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageIconUrl>https://avatars3.githubusercontent.com/u/32297579?s=460&amp;v=4</PackageIconUrl>
+    <PackageId>AndcultureCode.CSharp.Core</PackageId>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/AndcultureCode/AndcultureCode.CSharp.Core</PackageProjectUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.1.2</Version>
+    <VsxmdAutoDeleteXml>true</VsxmdAutoDeleteXml>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AndcultureCode.CSharp.Conductors/Aspects/LockingConductor.cs
+++ b/src/AndcultureCode.CSharp.Conductors/Aspects/LockingConductor.cs
@@ -8,6 +8,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AndcultureCode.CSharp.Conductors.Aspects
 {
+    /// <summary>
+    /// Repository implementation for handling ILockable entiteis
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     public class LockingConductor<T> : Conductor, ILockingConductor<T>
         where T : class, ILockable, IEntity
     {
@@ -21,22 +25,85 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
         #region Constants
 
+        /// <summary>
+        /// Error key indicating lock cannot be extended because the lock has expired
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_EXTEND_LOCK_LOCK_TIME_IN_PAST = $"{nameof(LockingConductor<T>)}.LockTimeInPast";
+
+        /// <summary>
+        /// Error key indicating the lock cannot be extended because it was locked by a different user
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_EXTEND_LOCK_LOCKED_BY_DIFFERENT_USER = $"{nameof(LockingConductor<T>)}.ExtendLock.RecordLockedByDifferentUser";
+
+        /// <summary>
+        /// Error key indicating the lock cannot be extended because the record to be locked could not
+        /// be found. It may have been deleted or is otherwise unavailable.
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_EXTEND_LOCK_RECORD_NOT_FOUND = $"{nameof(LockingConductor<T>)}.ExtendLock.ReadResultIsNull";
+
+        /// <summary>
+        /// Error key indicating the lock cannot be extended because the record is not locked
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_EXTEND_LOCK_RECORD_NOT_LOCKED = $"{nameof(LockingConductor<T>)}.ExtendLock.RecordIsNotLocked";
+
+        /// <summary>
+        /// Error key indicating the record cannot be locked because it is already in a locked state
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_LOCK_RECORD_ALREADY_LOCKED = $"{nameof(LockingConductor<T>)}.{typeof(T).Name}.IsLocked";
+
+        /// <summary>
+        /// Error key indicating the record cannot be locked because the record to be locked could not
+        /// be found. It may have been deleted or is otherwise unavailable.
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_LOCK_RECORD_NOT_FOUND = $"{nameof(LockingConductor<T>)}.Lock.ReadResult.ResultObjectIsNull";
+
+        /// <summary>
+        /// Error key indicating the record cannot be locked because the desired lockTime is in the past
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_LOCK_TIME_IN_PAST = $"{nameof(LockingConductor<T>)}.LockTimeInPast";
+
+        /// <summary>
+        /// Error key indicating the record cannot be unlocked because the record to be unlocked could not
+        /// be found. It may have been deleted or is otherwise unavailable.
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_UNLOCK_RECORD_NOT_FOUND = $"{nameof(LockingConductor<T>)}.Unlock.ReadResultIsNull";
+
+        /// <summary>
+        /// Error key indicating the lock could not be validated because the item to be validated is null
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_VALIDATE_LOCK_ITEM_IS_NULL = $"{nameof(LockingConductor<T>)}.ValidateLock.{typeof(T).Name}.IsNull";
+
+        /// <summary>
+        /// Error key indicating the lock could not be validated because the item is not in a locked state
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_VALIDATE_LOCK_ITEM_NOT_LOCKED = $"{nameof(LockingConductor<T>)}.ValidateLock.{typeof(T).Name}.IsNotLocked";
+
+        /// <summary>
+        /// Error key indicating the lock could not be validated because the resource was locked by a different user
+        /// </summary>
+        /// <returns></returns>
         public static readonly string ERROR_VALIDATE_LOCK_LOCKED_BY_DIFFERENT_USER = $"{nameof(LockingConductor<T>)}.ValidateLock.{typeof(T).Name}.LockedByDifferentUser";
 
         #endregion Constants
 
         #region Constructor
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="repositoryReadConductor"></param>
+        /// <param name="repositoryUpdateConductor"></param>
         public LockingConductor(
             ILogger<LockingConductor<T>> logger,
             IRepositoryReadConductor<T> repositoryReadConductor,
@@ -52,6 +119,17 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
 
         #region ILockingConductor
 
+        /// <summary>
+        /// Updates the locking fields to be set, which denotes that the user locking the record should
+        /// have exclusive access to modifying it for the lock's duration. This, however, does
+        /// not prohibit the record from being modified by others. When a record is locked, the
+        /// ValidateLock method below should be used to determine if the record can be modified. This will
+        /// ensure that only the user that locked the record is actually able to modify its contents.
+        /// </summary>
+        /// <param name="id">The record id</param>
+        /// <param name="lockUntil">The time the record should be locked until</param>
+        /// <param name="lockedById">The id of the user locking the record</param>
+        /// <returns>the updated record if it is successfully locked, null otherwise</returns>
         public virtual IResult<T> Lock(long id, DateTimeOffset lockUntil, long? lockedById) => Do<T>.Try(r =>
         {
             var readResult = _repositoryReadConductor.FindById(id);
@@ -114,6 +192,13 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
             return record;
         }).Result;
 
+        /// <summary>
+        /// Updates the locking fields back to null, meaning any user will be able to acquire a lock
+        /// so they have exclusive access to editing it.
+        /// </summary>
+        /// <param name="id">The record id</param>
+        /// <param name="unlockedById">The id of the user unlocking the record</param>
+        /// <returns>the updated record if it is successfully unlocked, null otherwise</returns>
         public virtual IResult<T> Unlock(long id, long? unlockedById = null) => Do<T>.Try(r =>
         {
             var readResult = _repositoryReadConductor.FindById(id);
@@ -152,6 +237,14 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
             return record;
         }).Result;
 
+        /// <summary>
+        /// Updates the LockedUntil field for the record, allowing the user that locked
+        /// it to have the lock for a longer amount of time.
+        /// </summary>
+        /// <param name="id">The record id</param>
+        /// <param name="lockUntil">The time the record should be locked until</param>
+        /// <param name="updatedById">The id of the user updating the record's lock time</param>
+        /// <returns>the updated record if the lock is successfully extended, null otherwise</returns>
         public virtual IResult<T> ExtendLock(long id, DateTimeOffset lockUntil, long? updatedById) => Do<T>.Try(r =>
         {
             var readResult = _repositoryReadConductor.FindById(id);
@@ -223,6 +316,13 @@ namespace AndcultureCode.CSharp.Conductors.Aspects
             return record;
         }).Result;
 
+        /// <summary>
+        /// Used to determine whether or not the user attempting to update the record is the
+        /// user that has the lock, AND that the lock is still valid (i.e. not expired).
+        /// </summary>
+        /// <param name="item">The item</param>
+        /// <param name="currentUserId">The current user id</param>
+        /// <returns>true if the lock is still active and is locked by the current user, false otherwise</returns>
         public virtual IResult<bool> ValidateLock(T item, long? currentUserId = null) => Do<bool>.Try(r =>
         {
             if (item == null)

--- a/src/AndcultureCode.CSharp.Conductors/RepositoryConductor.cs
+++ b/src/AndcultureCode.CSharp.Conductors/RepositoryConductor.cs
@@ -156,7 +156,7 @@ namespace AndcultureCode.CSharp.Conductors
         public virtual IResult<bool> BulkDelete(IEnumerable<T> items, long? deletedById = default(long?), bool soft = true) => _deleteConductor.BulkDelete(items, deletedById, soft);
         public virtual IResult<bool> Delete(long id, long? deletedById = default(long?), bool soft = true) => _deleteConductor.Delete(id, deletedById, soft);
         public virtual IResult<bool> Delete(T o, long? deletedById = default(long?), bool soft = true) => _deleteConductor.Delete(o, deletedById, soft);
-
+        public IResult<bool> Delete(IEnumerable<T> items, long? deletedById = null, long batchSize = 100, bool soft = true) => _deleteConductor.Delete(items, deletedById, batchSize, soft);
         public virtual IResult<bool> Restore(T o) => _deleteConductor.Restore(o);
         public virtual IResult<bool> Restore(long id) => _deleteConductor.Restore(id);
 
@@ -218,10 +218,12 @@ namespace AndcultureCode.CSharp.Conductors
         public virtual IResult<bool> Update(T item, long? updatedBy = default(long?)) => _updateConductor.Update(item, updatedBy);
         public virtual IResult<bool> Update(IEnumerable<T> items, long? updatedBy = default(long?)) => _updateConductor.Update(items, updatedBy);
 
+
+
         #endregion Update
 
 
-        
+
         #endregion Public Methods
     }
 }

--- a/src/AndcultureCode.CSharp.Conductors/RepositoryDeleteConductor.cs
+++ b/src/AndcultureCode.CSharp.Conductors/RepositoryDeleteConductor.cs
@@ -39,8 +39,10 @@ namespace AndcultureCode.CSharp.Conductors
         public virtual IResult<bool> Delete(long id, long? deletedById = default(long?), bool soft = true) => _repository.Delete(id, deletedById, soft);
         public virtual IResult<bool> Delete(T o,     long? deletedById = default(long?), bool soft = true) => _repository.Delete(o,  deletedById, soft);
 
+        public virtual IResult<bool> Delete(IEnumerable<T> items, long? deletedById = null, long batchSize = 100, bool soft = true) => _repository.Delete(items, deletedById, batchSize);
         public virtual IResult<bool> Restore(T o)     => _repository.Restore(o);
         public virtual IResult<bool> Restore(long id) => _repository.Restore(id);
+
 
         #endregion IRepositoryDeleteConductor Implementation
     }

--- a/test/AndcultureCode.CSharp.Conductors.Tests/AndcultureCode.CSharp.Conductors.Tests.csproj
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/AndcultureCode.CSharp.Conductors.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.3.0" />
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.5.15" />
     <PackageReference Include="AndcultureCode.CSharp.Testing" Version="0.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
@@ -33,10 +33,10 @@ namespace AndcultureCode.CSharp.Conductors.Tests
         )
         {
             return new RepositoryConductor<Entity>(
-                createConductor?.Object,
-                readConductor?.Object,
-                updateConductor?.Object,
-                deleteConductor?.Object
+                createConductor: createConductor?.Object,
+                readConductor: readConductor?.Object,
+                updateConductor: updateConductor?.Object,
+                deleteConductor: deleteConductor?.Object
             );
         }
 

--- a/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
@@ -27,16 +27,16 @@ namespace AndcultureCode.CSharp.Conductors.Tests
 
         private IRepositoryConductor<Entity> SetupSut(
             Mock<IRepositoryCreateConductor<Entity>> createConductor = null,
+            Mock<IRepositoryDeleteConductor<Entity>> deleteConductor = null,
             Mock<IRepositoryReadConductor<Entity>>   readConductor   = null,
-            Mock<IRepositoryUpdateConductor<Entity>> updateConductor = null,
-            Mock<IRepositoryDeleteConductor<Entity>> deleteConductor = null
+            Mock<IRepositoryUpdateConductor<Entity>> updateConductor = null
         )
         {
             return new RepositoryConductor<Entity>(
                 createConductor: createConductor?.Object,
+                deleteConductor: deleteConductor?.Object,
                 readConductor: readConductor?.Object,
-                updateConductor: updateConductor?.Object,
-                deleteConductor: deleteConductor?.Object
+                updateConductor: updateConductor?.Object
             );
         }
 

--- a/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
@@ -518,7 +518,7 @@ namespace AndcultureCode.CSharp.Conductors.Tests
         #region Delete
 
         [Fact]
-        public void Delete_When_Delete_HasErrors_Then_Returns_False_Errors()
+        public void Delete_When_Delete_HasErrors_Then_Returns_False_With_Errors()
         {
             // Arrange
             var entities = new List<Entity>();

--- a/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
+++ b/test/AndcultureCode.CSharp.Conductors.Tests/RepositoryConductorTest.cs
@@ -6,6 +6,8 @@ using AndcultureCode.CSharp.Core.Interfaces.Conductors;
 using AndcultureCode.CSharp.Core.Models;
 using AndcultureCode.CSharp.Core.Models.Entities;
 using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Testing.Extensions.Mocks;
+using AndcultureCode.CSharp.Testing.Extensions.Mocks.Conductors;
 using AndcultureCode.CSharp.Testing.Tests;
 using Moq;
 using Shouldly;
@@ -40,7 +42,7 @@ namespace AndcultureCode.CSharp.Conductors.Tests
             );
         }
 
-        #region CreateOrUpdate
+        #region BulkCreateOrUpdate
 
         [Fact]
         public void BulkCreateOrUpdate_When_Items_Is_Null_Then_Returns_Null()
@@ -233,7 +235,7 @@ namespace AndcultureCode.CSharp.Conductors.Tests
             bulkCreateOrUpdateResponse.ResultObject.Count().ShouldBe(1);
         }
 
-        #endregion
+        #endregion BulkCreateOrUpdate
 
         #region CreateOrUpdate
 
@@ -511,6 +513,48 @@ namespace AndcultureCode.CSharp.Conductors.Tests
             result.ResultObject.ShouldBe(createdEntities);
         }
 
-        #endregion
+        #endregion CreateOrUpdate
+
+        #region Delete
+
+        [Fact]
+        public void Delete_When_Delete_HasErrors_Then_Returns_False_Errors()
+        {
+            // Arrange
+            var entities = new List<Entity>();
+            var mockDeleteConductor = new Mock<IRepositoryDeleteConductor<Entity>>();
+            mockDeleteConductor.Setup(
+                m => m.Delete(It.IsAny<IEnumerable<Entity>>(), It.IsAny<long?>(), It.IsAny<long>(), It.IsAny<bool>()
+            )).ReturnsBasicErrorResult();
+            var sut = SetupSut(deleteConductor: mockDeleteConductor);
+
+            // Act
+            var result = sut.Delete(entities, null, 100, true);
+
+            // Assert
+            result.ShouldHaveErrorsFor(BASIC_ERROR_KEY);
+            result.ResultObject.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Delete_When_Delete_Succeeds_Then_Returns_True()
+        {
+            // Arrange
+            var entities = new List<Entity>();
+            var mockDeleteConductor = new Mock<IRepositoryDeleteConductor<Entity>>();
+            mockDeleteConductor.Setup(
+                m => m.Delete(It.IsAny<IEnumerable<Entity>>(), It.IsAny<long?>(), It.IsAny<long>(), It.IsAny<bool>()
+            )).ReturnsGivenResult(true);
+            var sut = SetupSut(deleteConductor: mockDeleteConductor);
+
+            // Act
+            var result = sut.Delete(entities, null, 100, true);
+
+            // Assert
+            result.ShouldNotHaveErrors();
+            result.ResultObject.ShouldBeTrue();
+        }
+
+        #endregion Delete
     }
 }


### PR DESCRIPTION
Adding doc comments to locking conductor. 
Revving version of Core package
Implementing the Delete for IEnumerable method.

https://github.com/AndcultureCode/AndcultureCode.CSharp.Conductors/issues/7
- [x ] Related GitHub issue(s) linked in PR description
- [x ] Destination branch merged, built and tested with your changes
- [x ] Code formatted and follows best practices and patterns
- [x ] Code builds cleanly (no _additional_ warnings or errors)
- [x ] Manually tested
- [x ] Automated tests are passing
- [x ] No _decreases_ in automated test coverage
- [x ] Documentation updated (readme, docs, comments, etc.)
- [x ] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
